### PR TITLE
商品一覧ページ実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,5 +1,8 @@
 class ProductsController < ApplicationController
   def index
-    
+    @products =Product.all
+  end
+
+  def new
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,11 +5,13 @@ class Product < ApplicationRecord
   has_many :users, dependent: :destroy
   belongs_to :brand
   belongs_to :category
+  belongs_to :seller, class_name: "User"
+  belongs_to :buyer, class_name: "User"
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :size
   belongs_to_active_hash :condition
   belongs_to_active_hash :sendingday
   belongs_to_active_hash :postage
   belongs_to_active_hash :sendingtype
-  belongs_to :seller, class_name: "User"
-  belongs_to :buyer, class_name: "User"
 end

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -80,17 +80,22 @@
         =link_to "#", class:"product" do
           %h3.title 新規投稿商品
       .productLists
-        .productList
-          =link_to "#", class:"listimage" do
-            %figure.productList--img
-            .productList__body
-              %h3.name テスト
-              .details
-                %ul.price
-                  %li 10000円
-                  %li.icon 
-                    =icon('fa','star')
-                %p.tax (税込)
+        - @products.each do |product|
+          .productList
+            =link_to "#", class:"listimage" do
+              %figure.productList--img
+                -# = image_tag src = product.product_image(id)
+              .productList__body
+                %h3.name 
+                  = product.name
+                .details
+                  %ul.price
+                    %li 
+                      = product.price
+                      円
+                    %li.icon 
+                      =icon('fa','star')
+                  %p.tax (税込)
   %section.pickupContainer
     %h2.head ピックアップブランド
     .productBox


### PR DESCRIPTION
#what
商品一覧ページ実装（画像の表示と売り切れの際のビュー表示以外）
アクティブハッシュの継承

#why
topページで商品の一覧を見えるようにする
商品出品機能を実装を先にしなければならない為一旦中断
