### PR TITLE
[WIP]クレジットカード登録/削除機能の実装

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,6 +3,7 @@
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title FinalApp
+    %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'


### PR DESCRIPTION
# What
フリマアプリにて、ユーザーのクレジットカード情報を、登録/削除できる機能の実装をおこなう。

# Why
ユーザーの購入の利便性の向上のため

# How
pay.jpを利用して実装を行う。