### PR TITLE
ユーザー登録機能導入

### DIFF
--- a/app/assets/stylesheets/new_user_registration.scss
+++ b/app/assets/stylesheets/new_user_registration.scss
@@ -124,7 +124,7 @@
         justify-content: center;
         padding-bottom: 20px;
         .last_name {
-          padding: 0 5px 0 5px;
+          
           #user_family_name {
             border: 1px solid #000000;  /* 枠線 */
             border-radius: 4px;   /* 角丸 */
@@ -167,7 +167,7 @@
         justify-content: center;
         padding-bottom: 20px;
         .last_name {
-          padding: 0 5px 0 5px;
+          
           #user_family_name_kana {
             border: 1px solid #000000;  /* 枠線 */
             border-radius: 4px;   /* 角丸 */
@@ -304,7 +304,7 @@
       }
     }
 
-    #user_sending_address_attributes_prefecture_code {
+    #user_sending_address_attributes_prefecture_code_id {
       border: 1px solid #000000;  /* 枠線 */
       border-radius: 4px;   /* 角丸 */
       padding: 0.5em;          /* 内側の余白量 */
@@ -385,7 +385,7 @@
         justify-content: center;
         padding-bottom: 20px;
         .last_name {
-          padding: 0 5px 0 5px;
+          
           #user_sending_address_attributes_family_name {
             border: 1px solid #000000;  /* 枠線 */
             border-radius: 4px;   /* 角丸 */
@@ -428,7 +428,7 @@
         justify-content: center;
         padding-bottom: 20px;
         .last_name {
-          padding: 0 5px 0 5px;
+          
           #user_sending_address_attributes_family_name_kana {
             border: 1px solid #000000;  /* 枠線 */
             border-radius: 4px;   /* 角丸 */

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,7 +11,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     
     @user = User.new(user_params)
-    
+
     if @user.save 
       sign_in(:user, @user) #登録後ログイン状態になるようにしている
       redirect_to complete_users_path, notice: '登録が完了しました'
@@ -32,7 +32,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   private
   def user_params
-    params.require(:user).permit(:nickname, :email, :password, :first_name, :family_name, :first_name_kana, :family_name_kana, :birth_date, :image, :introduction, sending_address_attributes:[:id, :first_name, :family_name, :first_name_kana, :family_name_kana, :post_code, :prefecture_code, :city, :house_number, :building_name, :phone_number, :user_id])
+    params.require(:user).permit(:nickname, :email, :password, :first_name, :family_name, :first_name_kana, :family_name_kana, :birth_date, :image, :introduction, sending_address_attributes:[:id, :first_name, :family_name, :first_name_kana, :family_name_kana, :post_code, :prefecture_code_id, :city, :house_number, :building_name, :phone_number, :user_id])
     #usersテーブル上パスワードはencrypted_passwordであるが、パラメータ上passwordとなるため上記ように記載
     # ユーザー登録の際にsending_address_attributes:を付属させることでsending_addressesテーブルにもデータを入れることが可能。user_idは自動的にmergeされる。
   end

--- a/app/models/sending_address.rb
+++ b/app/models/sending_address.rb
@@ -2,4 +2,7 @@ class SendingAddress < ApplicationRecord
   belongs_to :user
 
   validates :first_name, :family_name, :first_name_kana, :family_name_kana, :post_code, :prefecture_code, :city, :house_number, presence: true
+  
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture_code
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,7 @@ class User < ApplicationRecord
   validates :nickname, :password, :email, :family_name, :first_name, :first_name_kana, :family_name_kana, :birth_date, presence: true
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+         
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture_code
 end

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -100,7 +100,8 @@
               都道府県
               %span.required 必須
             .prefecture
-              = i.text_field :prefecture_code
+              -# = i.text_field :prefecture_code
+              = i.collection_select :prefecture_code_id, PrefectureCode.all, :id, :name
           .city
             .label
               市区町村

--- a/db/migrate/20200928113514_rename_prefecture_code_column_to_sending_addresses.rb
+++ b/db/migrate/20200928113514_rename_prefecture_code_column_to_sending_addresses.rb
@@ -1,0 +1,5 @@
+class RenamePrefectureCodeColumnToSendingAddresses < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :sending_addresses, :prefecture_code, :prefecture_code_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2020_09_22_111118) do
-
-# ActiveRecord::Schema.define(version: 2020_09_16_061724) do
-
+ActiveRecord::Schema.define(version: 2020_09_28_113514) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -72,7 +68,7 @@ ActiveRecord::Schema.define(version: 2020_09_22_111118) do
     t.integer "price", null: false
     t.bigint "category_id"
     t.bigint "brand_id"
-    t.string "size", default: ""
+    t.string "size"
     t.integer "condition", null: false
     t.integer "sendingday", null: false
     t.integer "postage", null: false
@@ -89,18 +85,13 @@ ActiveRecord::Schema.define(version: 2020_09_22_111118) do
     t.index ["seller_id"], name: "index_products_on_seller_id"
   end
 
-  create_table "searches", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "sending_addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "family_name", null: false
     t.string "first_name_kana", null: false
     t.string "family_name_kana", null: false
     t.string "post_code", null: false
-    t.integer "prefecture_code", null: false
+    t.integer "prefecture_code_id", null: false
     t.string "city", null: false
     t.string "house_number", null: false
     t.string "building_name"
@@ -112,14 +103,9 @@ ActiveRecord::Schema.define(version: 2020_09_22_111118) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "nickname", null: false
+    t.string "email", null: false
+    t.string "encrypted_password", null: false
     t.string "first_name", null: false
     t.string "family_name", null: false
     t.string "first_name_kana", null: false
@@ -127,6 +113,11 @@ ActiveRecord::Schema.define(version: 2020_09_22_111118) do
     t.date "birth_date", null: false
     t.string "image"
     t.text "introduction"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/sending_addresses.rb
+++ b/spec/factories/sending_addresses.rb
@@ -1,5 +1,15 @@
 FactoryBot.define do
+
   factory :sending_address do
+    first_name            {"kkk"}
+    first_name_kana       {"カタカナ"}
+    family_name             {"kkk"}
+    family_name_kana        {"カタカナ"}
+    post_code             {"1234567"}
+    prefecture_code            {"19"}
+    city                 {"名古屋市中川区"}
+    house_number              {"123"}
+    user_id {"1"}
     
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,15 @@
 FactoryBot.define do
+
   factory :user do
+    first_name            {"kkk"}
+    first_name_kana       {"カタカナ"}
+    family_name             {"kkk"}
+    family_name_kana        {"カタカナ"}
+    nickname              {"abe"}
+    birth_date            {"1940-08-16"}
+    email                 {"kkk@email.com"}
+    password              {"00000000"}
+    password_confirmation {"00000000"}
     
   end
 end

--- a/spec/models/sending_address_spec.rb
+++ b/spec/models/sending_address_spec.rb
@@ -1,37 +1,65 @@
 require 'rails_helper'
 
 describe User do
+  before do
+    @sending_address = build(:sending_address)
+  end
+
   describe '#create' do
     it "郵便番号がないと登録できないこと" do
-      sending_address = build(:sending_address, post_code: "")
+      @sending_address.post_code = ""
       # factory_botを使用
-      sending_address.valid?
-      expect(sending_address.errors[:post_code]).to include("を入力してください")
+      @sending_address.valid?
+      expect(@sending_address.errors[:post_code]).to include("を入力してください")
       # 当アプリは日本語版へ変更しているためinclude("can't be blank")にするとエラーが生じる。
     end
 
     it "県名がないと登録できないこと" do
-      sending_address = build(:sending_address, prefecture_code: "")
-      sending_address.valid?
-      expect(sending_address.errors[:prefecture_code]).to include("を入力してください")
+      @sending_address.prefecture_code = ""
+      @sending_address.valid?
+      expect(@sending_address.errors[:prefecture_code]).to include("を入力してください")
     end
 
     it "市町村がないと登録できないこと" do
-      sending_address = build(:sending_address, city: "")
-      sending_address.valid?
-      expect(sending_address.errors[:city]).to include("を入力してください")
+      @sending_address.city = ""
+      @sending_address.valid?
+      expect(@sending_address.errors[:city]).to include("を入力してください")
     end
 
     it "番地がないと登録できないこと" do
-      sending_address = build(:sending_address, house_number: "")
-      sending_address.valid?
-      expect(sending_address.errors[:house_number]).to include("を入力してください")
+      @sending_address.house_number = ""
+      @sending_address.valid?
+      expect(@sending_address.errors[:house_number]).to include("を入力してください")
+    end
+
+    it "名前がない場合は登録できないこと" do
+      @sending_address.first_name = ""
+      @sending_address.valid?
+      expect(@sending_address.errors[:first_name]).to include("を入力してください")
+    end
+
+    it "名前(カナ)がない場合は登録できないこと" do
+      @sending_address.first_name_kana = ""
+      @sending_address.valid?
+      expect(@sending_address.errors[:first_name_kana]).to include("を入力してください")
+    end
+
+    it "苗字がない場合は登録できないこと" do
+      @sending_address.family_name = ""
+      @sending_address.valid?
+      expect(@sending_address.errors[:family_name]).to include("を入力してください")
+    end
+
+    it "苗字(カナ)がない場合は登録できないこと" do
+      @sending_address.family_name_kana = ""
+      @sending_address.valid?
+      expect(@sending_address.errors[:family_name_kana]).to include("を入力してください")
     end
 
     it "user_idがないと登録できないこと" do
-      sending_address = build(:sending_address, user_id: "")
-      sending_address.valid?
-      expect(sending_address.errors[:user_id])
+      @sending_address.user_id = ""
+      @sending_address.valid?
+      expect(@sending_address.errors[:user_id])
     end
   end
 end

--- a/spec/models/sending_address_spec.rb
+++ b/spec/models/sending_address_spec.rb
@@ -1,5 +1,37 @@
 require 'rails_helper'
 
-RSpec.describe SendingAddress, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe User do
+  describe '#create' do
+    it "郵便番号がないと登録できないこと" do
+      sending_address = build(:sending_address, post_code: "")
+      # factory_botを使用
+      sending_address.valid?
+      expect(sending_address.errors[:post_code]).to include("を入力してください")
+      # 当アプリは日本語版へ変更しているためinclude("can't be blank")にするとエラーが生じる。
+    end
+
+    it "県名がないと登録できないこと" do
+      sending_address = build(:sending_address, prefecture_code: "")
+      sending_address.valid?
+      expect(sending_address.errors[:prefecture_code]).to include("を入力してください")
+    end
+
+    it "市町村がないと登録できないこと" do
+      sending_address = build(:sending_address, city: "")
+      sending_address.valid?
+      expect(sending_address.errors[:city]).to include("を入力してください")
+    end
+
+    it "番地がないと登録できないこと" do
+      sending_address = build(:sending_address, house_number: "")
+      sending_address.valid?
+      expect(sending_address.errors[:house_number]).to include("を入力してください")
+    end
+
+    it "user_idがないと登録できないこと" do
+      sending_address = build(:sending_address, user_id: "")
+      sending_address.valid?
+      expect(sending_address.errors[:user_id])
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,48 +1,82 @@
 require 'rails_helper'
 
 describe User do
+  before do
+    @user = build(:user)
+  end
+  
   describe '#create' do
     it "nicknameがない場合は登録できないこと" do
-      user = build(:user, nickname: "")
-      # factory_botを使用
-      user.valid?
-      expect(user.errors[:nickname]).to include("を入力してください")
+      @user.nickname = ""
+      @user.valid?
+      expect(@user.errors[:nickname]).to include("を入力してください")
       # 当アプリは日本語版へ変更しているためinclude("can't be blank")にするとエラーが生じる。
     end
 
     it "emailがない場合は登録できないこと" do
-      user = build(:user, email: "")
-      user.valid?
-      expect(user.errors[:email]).to include("を入力してください")
+      @user.email = ""
+      @user.valid?
+      expect(@user.errors[:email]).to include("を入力してください")
     end
 
     it "passwordがない場合は登録できないこと" do
-      user = build(:user, password: "")
-      user.valid?
-      expect(user.errors[:password]).to include("を入力してください")
+      @user.password = ""
+      @user.valid?
+      expect(@user.errors[:password]).to include("を入力してください")
     end
 
     it "passwordが存在してもpassword_confirmationがない場合は登録できないこと" do
-      user = build(:user, password_confirmation: "")
-      user.valid?
-      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
+      @user.password_confirmation = ""
+      @user.valid?
+      expect(@user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
     end
 
     it " passwordが6文字以下であれば登録できないこと " do
-      user = build(:user, password: "000000", password_confirmation: "000000")
-      user.valid?
-      expect(user.errors[:password]).to include("は7文字以上で入力してください")
+      @user.password = "000000"
+      @user.password_confirmation = "000000"
+      @user.valid?
+      expect(@user.errors[:password]).to include("は7文字以上で入力してください")
     end
 
     it " passwordが7文字以上であれば登録できること " do
-      user = build(:user, password: "1234567", password_confirmation: "1234567")
-      user.valid?
-      expect(user).to be_valid
+      @user.password = "0000000"
+      @user.password_confirmation = "0000000"
+      @user.valid?
+      expect(@user).to be_valid
+    end
+
+    it "名前がない場合は登録できないこと" do
+      @user.first_name = ""
+      @user.valid?
+      expect(@user.errors[:first_name]).to include("を入力してください")
+    end
+
+    it "名前(カナ)がない場合は登録できないこと" do
+      @user.first_name_kana = ""
+      @user.valid?
+      expect(@user.errors[:first_name_kana]).to include("を入力してください")
+    end
+
+    it "苗字がない場合は登録できないこと" do
+      @user.family_name = ""
+      @user.valid?
+      expect(@user.errors[:family_name]).to include("を入力してください")
+    end
+
+    it "苗字(カナ)がない場合は登録できないこと" do
+      @user.family_name_kana = ""
+      @user.valid?
+      expect(@user.errors[:family_name_kana]).to include("を入力してください")
+    end
+
+    it "生年月日がない場合は登録できないこと" do
+      @user.birth_date = ""
+      @user.valid?
+      expect(@user.errors[:birth_date]).to include("を入力してください")
     end
 
     it "必須項目が埋められていれば登録できること" do
-      user = build(:user)
-      expect(user).to be_valid
+      expect(@user).to be_valid
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,48 @@
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe User do
+  describe '#create' do
+    it "nicknameがない場合は登録できないこと" do
+      user = build(:user, nickname: "")
+      # factory_botを使用
+      user.valid?
+      expect(user.errors[:nickname]).to include("を入力してください")
+      # 当アプリは日本語版へ変更しているためinclude("can't be blank")にするとエラーが生じる。
+    end
+
+    it "emailがない場合は登録できないこと" do
+      user = build(:user, email: "")
+      user.valid?
+      expect(user.errors[:email]).to include("を入力してください")
+    end
+
+    it "passwordがない場合は登録できないこと" do
+      user = build(:user, password: "")
+      user.valid?
+      expect(user.errors[:password]).to include("を入力してください")
+    end
+
+    it "passwordが存在してもpassword_confirmationがない場合は登録できないこと" do
+      user = build(:user, password_confirmation: "")
+      user.valid?
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
+    end
+
+    it " passwordが6文字以下であれば登録できないこと " do
+      user = build(:user, password: "000000", password_confirmation: "000000")
+      user.valid?
+      expect(user.errors[:password]).to include("は7文字以上で入力してください")
+    end
+
+    it " passwordが7文字以上であれば登録できること " do
+      user = build(:user, password: "1234567", password_confirmation: "1234567")
+      user.valid?
+      expect(user).to be_valid
+    end
+
+    it "必須項目が埋められていれば登録できること" do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
+  config.include FactoryBot::Syntax::Methods
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
## What
ユーザー登録機能の導入

## Why 
ユーザーを登録し、出品、購入を行うため。

## 補足
以前にユーザー登録機能を作成した際に誤ってマージを行ってしまっております。
その際のプルリクエストが下記となります。
https://github.com/Yama1122/freemarket_sample_77a/pull/26
今回はそれに加えて単体テストを作成しております。