### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/assets/stylesheets/flash_msg.scss
+++ b/app/assets/stylesheets/flash_msg.scss
@@ -1,9 +1,11 @@
 .notice {
   background-color: aqua;
   text-align: center;
+  color:gray;
 }
 
 .alert {
   background-color: rgb(255, 96, 75);
   text-align: center;
+  color:white;
 }

--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -1161,3 +1161,26 @@ body{
     opacity:1;
   }
 }
+
+// 商品削除ページ
+#product_deleteBtn{
+  width:60%;
+  height:60px;
+  line-height: 60px;
+  border-radius: 5px;
+  background-color:#ea352d;
+  margin-top:30px;
+}
+
+#delete_confirmation{
+  height:500px;
+}
+
+#delete_change{
+  text-align: right;
+  padding-right:40px;
+  padding-top:70px;
+  a{
+    color:#3ccace;
+  }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,7 +1,7 @@
 class ProductsController < ApplicationController
 
-  before_action :set_product, only: [:show]
-  before_action :set_product_image
+  before_action :set_product, only: [:show,:destroy,:delete]
+  before_action :set_product_image, except: :index
   
  
   def index
@@ -9,6 +9,20 @@ class ProductsController < ApplicationController
   end
 
   def new
+  end
+
+  def delete
+    unless current_user.id == @product.seller_id
+      redirect_to product_path(params[:id]),alert:"出品者のみ削除が行なえます"
+    end
+      
+  end
+
+  def destroy
+    @product.destroy
+    if @product.destroy
+      redirect_to products_path
+    end
   end
 
   def show

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,7 +19,6 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    @product.destroy
     if @product.destroy
       redirect_to products_path
     end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,7 +2,7 @@ class Product < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :product_images, dependent: :destroy
   has_many :favorites
-  has_many :users, dependent: :destroy
+  belongs_to :user
   belongs_to :brand
   belongs_to :category
   belongs_to :seller, class_name: "User"

--- a/app/views/products/_show_login.html.haml
+++ b/app/views/products/_show_login.html.haml
@@ -114,7 +114,7 @@
           = link_to "#" do
             .itemBox__editArea__editBtn
               編集
-          = link_to "#" do
+          = link_to delete_product_path(params[:id]) do
             .itemBox__editArea__editBtn
               削除    
 

--- a/app/views/products/delete.html.haml
+++ b/app/views/products/delete.html.haml
@@ -1,0 +1,34 @@
+= render "sub_header"
+
+.purchase_detail_wrapper
+  .purchase_detail_wrapper__form#delete_confirmation
+    .top_text
+      以下の商品の削除を行います
+    .hr
+    .purchase-product
+      .purchase-product__wrapper
+        .purchase-product__wrapper__left
+          .purchase-product__wrapper__left__image
+            = image_tag @image.url, class: 'product2'
+        .purchase-product__wrapper__right    
+          .purchase-product__wrapper__right__name
+            %p 
+              = @product.name
+          .purchase-product__wrapper__right__price
+            %p (税込)送料込み
+            %p 
+              %span ¥
+              %p 
+                = @product.price
+    .hr     
+    .itemBox__purchace#product_deleteArea
+      = link_to product_path(params[:id]),method: :delete do
+        .itemBox__purchace__btn#product_deleteBtn
+          削除する 
+
+      .change#delete_change
+        = link_to product_path(params[:id]) do
+          商品ページに戻る
+          = icon("fas","chevron-right")
+
+= render "sub_footer"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,10 @@ Rails.application.routes.draw do
   }
   # deviseにてusersを作成し使用する場合、controllers: {registrations: 'users/registrations'｝が必要
   root to:'products#index'
-  resources :products, only: [:index,:show,:new] do
+  resources :products, only: [:index,:show,:new,:destroy] do
+    member do
+      get 'delete'
+    end
     resources :purchases do
       member do
         get 'confirmation'


### PR DESCRIPTION
# What
・商品削除機能の実装を行う。
・商品詳細ページから、商品削除確認ページへと遷移し削除を行えるようにする。
・出品者以外は商品の削除ができないようにする。

# Why
・商品を削除できるようにするため。
・自分の出品した商品が勝手に削除されないようにするため。