### PR TITLE
パンくずリスト機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,4 @@ gem 'dotenv-rails'
 gem 'carrierwave' 
 gem 'mini_magick'
 gem 'fog-aws'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,9 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.1.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     haml (5.2.0)
       temple (>= 0.8.0)
       tilt
@@ -383,6 +386,7 @@ DEPENDENCIES
   faker
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jp_prefecture

--- a/app/assets/stylesheets/_breadcrumbs.scss
+++ b/app/assets/stylesheets/_breadcrumbs.scss
@@ -3,6 +3,8 @@
   padding-left:50px;
   border-top: 1px solid #eee;
   font-size:14px;
+  box-shadow:0 3px 3px 0px rgba(0,0,0,0.16);
+  position: relative;
   a{
     color:black;
     padding:0 5px;

--- a/app/assets/stylesheets/_breadcrumbs.scss
+++ b/app/assets/stylesheets/_breadcrumbs.scss
@@ -1,0 +1,21 @@
+.breadcrumbs-list{
+  padding:15px;
+  padding-left:50px;
+  border-top: 1px solid #eee;
+  font-size:14px;
+  a{
+    color:black;
+    padding:0 5px;
+    &:hover{
+      color:orange;
+    }
+  }
+  span{
+    padding:0 5px;
+  }
+}
+
+.current{
+  font-weight:bold;
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,3 +21,4 @@
 @import "complete";
 @import "flash_msg";
 @import "categories";
+@import "breadcrumbs";

--- a/app/assets/stylesheets/categories.scss
+++ b/app/assets/stylesheets/categories.scss
@@ -102,6 +102,9 @@
       width:100%;
       display:flex;
       flex-wrap: wrap;
+      a{
+        color:black;
+      }
       &__content{
         width:125px;
         height:185px;

--- a/app/assets/stylesheets/products_show.scss
+++ b/app/assets/stylesheets/products_show.scss
@@ -384,6 +384,7 @@
           display:flex;
           align-content: center;
           justify-content: space-between;
+          
           &__left{
             &--name{
               font-weight:bold;
@@ -394,6 +395,9 @@
             &--price{
               p{
                 font-size:18px;
+                span{
+                  font-size: 18px;
+                }
               }
               span{
                 font-size:10px;

--- a/app/assets/stylesheets/products_show.scss
+++ b/app/assets/stylesheets/products_show.scss
@@ -27,8 +27,6 @@
       }
   }
 }
-// a {
-//   text-decoration: none;
 
   .itemBox{
     width:100%;

--- a/app/assets/stylesheets/products_show.scss
+++ b/app/assets/stylesheets/products_show.scss
@@ -14,6 +14,7 @@
   width:100%;
   margin:0 auto;
   padding-top:30px;
+  padding-bottom:30px;
   &__container{
     width:50%;
     margin: 0 auto;

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -176,6 +176,10 @@
   }
 }
 
+#user-submitBtn{
+  color:#fff;
+}
+
 
 
 .logout{

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -4,6 +4,7 @@ class CategoriesController < ApplicationController
 
   def show
     @category = Category.find(params[:id])
+    @products = @category.set_products
   end
 
   def search

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,8 +4,6 @@ class ProductsController < ApplicationController
 
   before_action :set_product, only: [:show,:destroy,:delete]
   before_action :set_product_image, except: [:index,:new,:create,:delete_done]
-  
- 
   def index
     @products = Product.all
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -45,6 +45,7 @@ class ProductsController < ApplicationController
 
   def show
     @category = @product.category
+    @products = Product.where(category_id:@category.id)
   end
 
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,4 +1,27 @@
 class Category < ApplicationRecord
   has_many :products
   has_ancestry
+
+  def set_products
+    # 親カテゴリーの場合
+    if self.root?
+      # 孫カテゴリーのidの商品をすべて取得
+      start_id = self.indirects.first.id
+      end_id = self.indirects.last.id
+      products = Product.where(category_id: start_id..end_id)
+      return products
+  
+      # 子カテゴリーの場合
+    elsif self.has_children?
+      # 孫カテゴリーのidの商品をすべて取得
+      start_id = self.children.first.id
+      end_id = self.children.last.id
+      products = Product.where(category_id: start_id..end_id)
+      return products
+  
+      # 孫カテゴリーの場合
+    else
+      return self.products
+    end
+  end
 end

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,5 +1,8 @@
 = render "layouts/main_header"
 
+- breadcrumb :category_index
+= render "layouts/breadcrumbs"
+
 .categoryIndex
   .categoryIndex__container
     .categoryIndex__container__name

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -15,7 +15,7 @@
         %span
           の商品一覧
     .categoryShow__container__list
-      - @category.products.each do |product|
+      - @products.each do |product|
         = link_to product_path(product.id) do
           .relatedItems__list__item#categoryProduct
             .relatedItems__list__item__image
@@ -39,77 +39,4 @@
                 .relatedItems__list__item__detail__right--count
                   0
       
-      -# .relatedItems__list__item#categoryProduct
-      -#   .relatedItems__list__item__image
-      -#     = image_tag "products/product1.png"
-      -#   .relatedItems__list__item__detail
-      -#     .relatedItems__list__item__detail__left
-      -#       .relatedItems__list__item__detail__left--name
-      -#         %p
-      -#           商品名
-      -#       .relatedItems__list__item__detail__left--price
-      -#         %p
-      -#           ¥3000
-      -#         %span  
-      -#           (税込み)
-      -#     .relatedItems__list__item__detail__right
-      -#       = icon("fas","star")
-      -#       .relatedItems__list__item__detail__right--count
-      -#         0
-
-      -# .relatedItems__list__item#categoryProduct
-      -#   .relatedItems__list__item__image
-      -#     = image_tag "products/product1.png"
-      -#   .relatedItems__list__item__detail
-      -#     .relatedItems__list__item__detail__left
-      -#       .relatedItems__list__item__detail__left--name
-      -#         %p
-      -#           商品名
-      -#       .relatedItems__list__item__detail__left--price
-      -#         %p
-      -#           ¥3000
-      -#         %span  
-      -#           (税込み)
-      -#     .relatedItems__list__item__detail__right
-      -#       = icon("fas","star")
-      -#       .relatedItems__list__item__detail__right--count
-      -#         0
-      
-      -# .relatedItems__list__item#categoryProduct
-      -#   .relatedItems__list__item__image
-      -#     = image_tag "products/product1.png"
-      -#   .relatedItems__list__item__detail
-      -#     .relatedItems__list__item__detail__left
-      -#       .relatedItems__list__item__detail__left--name
-      -#         %p
-      -#           商品名
-      -#       .relatedItems__list__item__detail__left--price
-      -#         %p
-      -#           ¥3000
-      -#         %span  
-      -#           (税込み)
-      -#     .relatedItems__list__item__detail__right
-      -#       = icon("fas","star")
-      -#       .relatedItems__list__item__detail__right--count
-      -#         0
-        
-      -# .relatedItems__list__item#categoryProduct
-      -#   .relatedItems__list__item__image
-      -#     = image_tag "products/product1.png"
-      -#   .relatedItems__list__item__detail
-      -#     .relatedItems__list__item__detail__left
-      -#       .relatedItems__list__item__detail__left--name
-      -#         %p
-      -#           商品名
-      -#       .relatedItems__list__item__detail__left--price
-      -#         %p
-      -#           ¥3000
-      -#         %span  
-      -#           (税込み)
-      -#     .relatedItems__list__item__detail__right
-      -#       = icon("fas","star")
-      -#       .relatedItems__list__item__detail__right--count
-      -#         0
-
-
 = render "layouts/footer"

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -15,95 +15,101 @@
         %span
           の商品一覧
     .categoryShow__container__list
-      .relatedItems__list__item#categoryProduct
-        .relatedItems__list__item__image
-          = image_tag "products/product1.png"
-        .relatedItems__list__item__detail
-          .relatedItems__list__item__detail__left
-            .relatedItems__list__item__detail__left--name
-              %p
-                商品名
-            .relatedItems__list__item__detail__left--price
-              %p
-                ¥3000
-              %span  
-                (税込み)
-          .relatedItems__list__item__detail__right
-            = icon("fas","star")
-            .relatedItems__list__item__detail__right--count
-              0
-      
-      .relatedItems__list__item#categoryProduct
-        .relatedItems__list__item__image
-          = image_tag "products/product1.png"
-        .relatedItems__list__item__detail
-          .relatedItems__list__item__detail__left
-            .relatedItems__list__item__detail__left--name
-              %p
-                商品名
-            .relatedItems__list__item__detail__left--price
-              %p
-                ¥3000
-              %span  
-                (税込み)
-          .relatedItems__list__item__detail__right
-            = icon("fas","star")
-            .relatedItems__list__item__detail__right--count
-              0
+      - @category.products.each do |product|
+        = link_to product_path(product.id) do
+          .relatedItems__list__item#categoryProduct
+            .relatedItems__list__item__image
+              = image_tag product .product_images[0].url.url
+            .relatedItems__list__item__detail
+              .relatedItems__list__item__detail__left
+                .relatedItems__list__item__detail__left--name
+                  %p
+                    = product.name
+                .relatedItems__list__item__detail__left--price
+                  %p
+                    %span
+                      ¥
+                    %span
+                      = product.price
 
-      .relatedItems__list__item#categoryProduct
-        .relatedItems__list__item__image
-          = image_tag "products/product1.png"
-        .relatedItems__list__item__detail
-          .relatedItems__list__item__detail__left
-            .relatedItems__list__item__detail__left--name
-              %p
-                商品名
-            .relatedItems__list__item__detail__left--price
-              %p
-                ¥3000
-              %span  
-                (税込み)
-          .relatedItems__list__item__detail__right
-            = icon("fas","star")
-            .relatedItems__list__item__detail__right--count
-              0
+                  %span  
+                    (税込み)
+              .relatedItems__list__item__detail__right
+                = icon("fas","star")
+                .relatedItems__list__item__detail__right--count
+                  0
       
-      .relatedItems__list__item#categoryProduct
-        .relatedItems__list__item__image
-          = image_tag "products/product1.png"
-        .relatedItems__list__item__detail
-          .relatedItems__list__item__detail__left
-            .relatedItems__list__item__detail__left--name
-              %p
-                商品名
-            .relatedItems__list__item__detail__left--price
-              %p
-                ¥3000
-              %span  
-                (税込み)
-          .relatedItems__list__item__detail__right
-            = icon("fas","star")
-            .relatedItems__list__item__detail__right--count
-              0
+      -# .relatedItems__list__item#categoryProduct
+      -#   .relatedItems__list__item__image
+      -#     = image_tag "products/product1.png"
+      -#   .relatedItems__list__item__detail
+      -#     .relatedItems__list__item__detail__left
+      -#       .relatedItems__list__item__detail__left--name
+      -#         %p
+      -#           商品名
+      -#       .relatedItems__list__item__detail__left--price
+      -#         %p
+      -#           ¥3000
+      -#         %span  
+      -#           (税込み)
+      -#     .relatedItems__list__item__detail__right
+      -#       = icon("fas","star")
+      -#       .relatedItems__list__item__detail__right--count
+      -#         0
+
+      -# .relatedItems__list__item#categoryProduct
+      -#   .relatedItems__list__item__image
+      -#     = image_tag "products/product1.png"
+      -#   .relatedItems__list__item__detail
+      -#     .relatedItems__list__item__detail__left
+      -#       .relatedItems__list__item__detail__left--name
+      -#         %p
+      -#           商品名
+      -#       .relatedItems__list__item__detail__left--price
+      -#         %p
+      -#           ¥3000
+      -#         %span  
+      -#           (税込み)
+      -#     .relatedItems__list__item__detail__right
+      -#       = icon("fas","star")
+      -#       .relatedItems__list__item__detail__right--count
+      -#         0
+      
+      -# .relatedItems__list__item#categoryProduct
+      -#   .relatedItems__list__item__image
+      -#     = image_tag "products/product1.png"
+      -#   .relatedItems__list__item__detail
+      -#     .relatedItems__list__item__detail__left
+      -#       .relatedItems__list__item__detail__left--name
+      -#         %p
+      -#           商品名
+      -#       .relatedItems__list__item__detail__left--price
+      -#         %p
+      -#           ¥3000
+      -#         %span  
+      -#           (税込み)
+      -#     .relatedItems__list__item__detail__right
+      -#       = icon("fas","star")
+      -#       .relatedItems__list__item__detail__right--count
+      -#         0
         
-      .relatedItems__list__item#categoryProduct
-        .relatedItems__list__item__image
-          = image_tag "products/product1.png"
-        .relatedItems__list__item__detail
-          .relatedItems__list__item__detail__left
-            .relatedItems__list__item__detail__left--name
-              %p
-                商品名
-            .relatedItems__list__item__detail__left--price
-              %p
-                ¥3000
-              %span  
-                (税込み)
-          .relatedItems__list__item__detail__right
-            = icon("fas","star")
-            .relatedItems__list__item__detail__right--count
-              0
+      -# .relatedItems__list__item#categoryProduct
+      -#   .relatedItems__list__item__image
+      -#     = image_tag "products/product1.png"
+      -#   .relatedItems__list__item__detail
+      -#     .relatedItems__list__item__detail__left
+      -#       .relatedItems__list__item__detail__left--name
+      -#         %p
+      -#           商品名
+      -#       .relatedItems__list__item__detail__left--price
+      -#         %p
+      -#           ¥3000
+      -#         %span  
+      -#           (税込み)
+      -#     .relatedItems__list__item__detail__right
+      -#       = icon("fas","star")
+      -#       .relatedItems__list__item__detail__right--count
+      -#         0
 
 
 = render "layouts/footer"

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,4 +1,11 @@
 = render "layouts/main_header"
+- if @category.root?
+  - breadcrumb :parent_category
+- elsif @category.has_children?
+  - breadcrumb :child_category
+- else
+  - breadcrumb :grandchild_category
+= render "layouts/breadcrumbs"
 
 .categoryShow
   .categoryShow__container

--- a/app/views/credit_cards/complete.html.haml
+++ b/app/views/credit_cards/complete.html.haml
@@ -1,6 +1,9 @@
 -# クレジットカード登録完了ページ
 = render "users/user_header"
 
+- breadcrumb :credit_new
+= render "layouts/breadcrumbs"
+
 .userShow
   .userShow__container
     .userShow__container__left

--- a/app/views/credit_cards/complete.html.haml
+++ b/app/views/credit_cards/complete.html.haml
@@ -20,7 +20,7 @@
               %li.userbtn 
                 やることリスト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to new_product_path do
               %li.userbtn 
                 出品する
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
@@ -82,7 +82,7 @@
               %li.userbtn 
                 クレジットカード一覧/削除
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to logout_user_path(current_user.id) do
               %li.userbtn 
                 ログアウト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")

--- a/app/views/credit_cards/delete.html.haml
+++ b/app/views/credit_cards/delete.html.haml
@@ -1,6 +1,9 @@
 -# クレジットカード削除完了ページ
 = render "users/user_header"
 
+- breadcrumb :credit_index
+= render "layouts/breadcrumbs"
+
 .userShow
   .userShow__container
     .userShow__container__left

--- a/app/views/credit_cards/delete.html.haml
+++ b/app/views/credit_cards/delete.html.haml
@@ -1,7 +1,7 @@
 -# クレジットカード削除完了ページ
 = render "users/user_header"
 
-- breadcrumb :credit_index
+- breadcrumb :credit_delete
 = render "layouts/breadcrumbs"
 
 .userShow
@@ -20,7 +20,7 @@
               %li.userbtn 
                 やることリスト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to new_product_path do
               %li.userbtn 
                 出品する
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -1,6 +1,9 @@
 -# クレジットカード新規登録ページ
 = render "users/user_header"
 
+- breadcrumb :credit_new
+= render "layouts/breadcrumbs"
+
 .userShow
   .userShow__container
     .userShow__container__left

--- a/app/views/credit_cards/new.html.haml
+++ b/app/views/credit_cards/new.html.haml
@@ -20,7 +20,7 @@
               %li.userbtn 
                 やることリスト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to new_product_path do
               %li.userbtn 
                 出品する
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
@@ -70,7 +70,7 @@
           %p 設定
         .userShow__container__left__config__content
           %ul
-            = link_to "#" do
+            = link_to edit_user_path(current_user.id) do
               %li.userbtn 
                 ユーザー情報更新
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
@@ -78,7 +78,7 @@
               %li.userbtn 
                 発送元・お届け先住所変更
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to logout_user_path(current_user.id) do
               %li.userbtn 
                 ログアウト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")

--- a/app/views/credit_cards/show.html.haml
+++ b/app/views/credit_cards/show.html.haml
@@ -20,7 +20,7 @@
               %li.userbtn 
                 やることリスト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to new_product_path do
               %li.userbtn 
                 出品する
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
@@ -70,7 +70,7 @@
           %p 設定
         .userShow__container__left__config__content
           %ul
-            = link_to "#" do
+            = link_to edit_user_path(current_user.id) do
               %li.userbtn 
                 ユーザー情報更新
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
@@ -78,7 +78,7 @@
               %li.userbtn 
                 発送元・お届け先住所変更
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to logout_user_path(current_user.id) do
               %li.userbtn 
                 ログアウト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")

--- a/app/views/credit_cards/show.html.haml
+++ b/app/views/credit_cards/show.html.haml
@@ -1,6 +1,9 @@
 -# 登録クレジットカード一覧ページ
 = render "users/user_header"
 
+- breadcrumb :credit_index
+= render "layouts/breadcrumbs"
+
 .userShow
   .userShow__container
     .userShow__container__left

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,2 +1,3 @@
 .breadcrumbs
+
   = breadcrumbs separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/layouts/_main_header.html.haml
+++ b/app/views/layouts/_main_header.html.haml
@@ -26,7 +26,8 @@
         %li.listsRight__item--login
           = link_to "マイページ", user_path(current_user.id), class: "login"
         %li.listsRight__item--new
-          =link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'new'
+          -# =link_to "ログアウト", destroy_user_session_path, method: :delete, class: 'new'
+          =link_to "ログアウト", logout_user_path(current_user.id), class: 'new'
     - else
       %ul.listsRight
         %li.listsRight__item--login

--- a/app/views/products/_show_login.html.haml
+++ b/app/views/products/_show_login.html.haml
@@ -55,9 +55,9 @@
                   %th
                     カテゴリー
                   %td
-                    = link_to category_path(@category.parent.parent),class:"itemBox__table--category" do
-                      -# 孫カテゴリが存在しない場合
-                      - if @category.parent.parent != nil  
+                    -# 孫カテゴリが存在しない場合
+                    - if @category.parent.parent != nil
+                      = link_to category_path(@category.parent.parent),class:"itemBox__table--category" do 
                         = @category.parent.parent.name
                     = link_to category_path(@category.parent),class:"itemBox__table--category" do
                       = @category.parent.name

--- a/app/views/products/_show_login.html.haml
+++ b/app/views/products/_show_login.html.haml
@@ -178,39 +178,4 @@
                     = icon("fas","star")
                     .relatedItems__list__item__detail__right--count
                       0
-          -# = link_to "#" do
-          -#   .relatedItems__list__item
-          -#     .relatedItems__list__item__image
-          -#       = image_tag "products/product1.png"
-          -#     .relatedItems__list__item__detail
-          -#       .relatedItems__list__item__detail__left
-          -#         .relatedItems__list__item__detail__left--name
-          -#           %p
-          -#             商品名
-          -#         .relatedItems__list__item__detail__left--price
-          -#           %p
-          -#             ¥3000
-          -#           %span  
-          -#             (税込み)
-          -#       .relatedItems__list__item__detail__right
-          -#         = icon("fas","star")
-          -#         .relatedItems__list__item__detail__right--count
-          -#           0
-          -# = link_to "#" do
-          -#   .relatedItems__list__item#categoryProduct
-          -#     .relatedItems__list__item__image
-          -#       = image_tag "products/product1.png"
-          -#     .relatedItems__list__item__detail
-          -#       .relatedItems__list__item__detail__left
-          -#         .relatedItems__list__item__detail__left--name
-          -#           %p
-          -#             商品名
-          -#         .relatedItems__list__item__detail__left--price
-          -#           %p
-          -#             ¥3000
-          -#           %span  
-          -#             (税込み)
-          -#       .relatedItems__list__item__detail__right
-          -#         = icon("fas","star")
-          -#         .relatedItems__list__item__detail__right--count
-          -#           0
+          

--- a/app/views/products/_show_login.html.haml
+++ b/app/views/products/_show_login.html.haml
@@ -156,57 +156,61 @@
               %span
                 をもっとみる
         .relatedItems__list
-          = link_to "#" do
-            .relatedItems__list__item
-              .relatedItems__list__item__image
-                = image_tag "products/product1.png"
-              .relatedItems__list__item__detail
-                .relatedItems__list__item__detail__left
-                  .relatedItems__list__item__detail__left--name
-                    %p
-                      商品名
-                  .relatedItems__list__item__detail__left--price
-                    %p
-                      ¥3000
-                    %span  
-                      (税込み)
-                .relatedItems__list__item__detail__right
-                  = icon("fas","star")
-                  .relatedItems__list__item__detail__right--count
-                    0
-          = link_to "#" do
-            .relatedItems__list__item
-              .relatedItems__list__item__image
-                = image_tag "products/product1.png"
-              .relatedItems__list__item__detail
-                .relatedItems__list__item__detail__left
-                  .relatedItems__list__item__detail__left--name
-                    %p
-                      商品名
-                  .relatedItems__list__item__detail__left--price
-                    %p
-                      ¥3000
-                    %span  
-                      (税込み)
-                .relatedItems__list__item__detail__right
-                  = icon("fas","star")
-                  .relatedItems__list__item__detail__right--count
-                    0
-          = link_to "#" do
-            .relatedItems__list__item#categoryProduct
-              .relatedItems__list__item__image
-                = image_tag "products/product1.png"
-              .relatedItems__list__item__detail
-                .relatedItems__list__item__detail__left
-                  .relatedItems__list__item__detail__left--name
-                    %p
-                      商品名
-                  .relatedItems__list__item__detail__left--price
-                    %p
-                      ¥3000
-                    %span  
-                      (税込み)
-                .relatedItems__list__item__detail__right
-                  = icon("fas","star")
-                  .relatedItems__list__item__detail__right--count
-                    0
+          - @products.each do |product|
+            = link_to product_path(product) do
+              .relatedItems__list__item
+                .relatedItems__list__item__image
+                  = image_tag product .product_images[0].url.url
+                .relatedItems__list__item__detail
+                  .relatedItems__list__item__detail__left
+                    .relatedItems__list__item__detail__left--name
+                      %p
+                        = product.name
+                    .relatedItems__list__item__detail__left--price
+                      %p
+                        %span
+                          ¥
+                        %span
+                          = product.price
+                      %span  
+                        (税込み)
+                  .relatedItems__list__item__detail__right
+                    = icon("fas","star")
+                    .relatedItems__list__item__detail__right--count
+                      0
+          -# = link_to "#" do
+          -#   .relatedItems__list__item
+          -#     .relatedItems__list__item__image
+          -#       = image_tag "products/product1.png"
+          -#     .relatedItems__list__item__detail
+          -#       .relatedItems__list__item__detail__left
+          -#         .relatedItems__list__item__detail__left--name
+          -#           %p
+          -#             商品名
+          -#         .relatedItems__list__item__detail__left--price
+          -#           %p
+          -#             ¥3000
+          -#           %span  
+          -#             (税込み)
+          -#       .relatedItems__list__item__detail__right
+          -#         = icon("fas","star")
+          -#         .relatedItems__list__item__detail__right--count
+          -#           0
+          -# = link_to "#" do
+          -#   .relatedItems__list__item#categoryProduct
+          -#     .relatedItems__list__item__image
+          -#       = image_tag "products/product1.png"
+          -#     .relatedItems__list__item__detail
+          -#       .relatedItems__list__item__detail__left
+          -#         .relatedItems__list__item__detail__left--name
+          -#           %p
+          -#             商品名
+          -#         .relatedItems__list__item__detail__left--price
+          -#           %p
+          -#             ¥3000
+          -#           %span  
+          -#             (税込み)
+          -#       .relatedItems__list__item__detail__right
+          -#         = icon("fas","star")
+          -#         .relatedItems__list__item__detail__right--count
+          -#           0

--- a/app/views/products/_show_not_login.html.haml
+++ b/app/views/products/_show_not_login.html.haml
@@ -50,9 +50,9 @@
                   %th
                     カテゴリー
                   %td
-                    = link_to category_path(@category.parent.parent),class:"itemBox__table--category" do
-                      -# 孫カテゴリが存在しない場合
-                      - if @category.parent.parent != nil  
+                    -# 孫カテゴリが存在しない場合
+                    - if @category.parent.parent != nil
+                      = link_to category_path(@category.parent.parent),class:"itemBox__table--category" do 
                         = @category.parent.parent.name
                     = link_to category_path(@category.parent),class:"itemBox__table--category" do
                       = @category.parent.name

--- a/app/views/products/_show_not_login.html.haml
+++ b/app/views/products/_show_not_login.html.haml
@@ -141,57 +141,27 @@
               %span
                 をもっとみる
         .relatedItems__list
-          = link_to "#" do
-            .relatedItems__list__item
-              .relatedItems__list__item__image
-                = image_tag "products/product1.png"
-              .relatedItems__list__item__detail
-                .relatedItems__list__item__detail__left
-                  .relatedItems__list__item__detail__left--name
-                    %p
-                      商品名
-                  .relatedItems__list__item__detail__left--price
-                    %p
-                      ¥3000
-                    %span  
-                      (税込み)
-                .relatedItems__list__item__detail__right
-                  = icon("fas","star")
-                  .relatedItems__list__item__detail__right--count
-                    0
-          = link_to "#" do
-            .relatedItems__list__item
-              .relatedItems__list__item__image
-                = image_tag "products/product1.png"
-              .relatedItems__list__item__detail
-                .relatedItems__list__item__detail__left
-                  .relatedItems__list__item__detail__left--name
-                    %p
-                      商品名
-                  .relatedItems__list__item__detail__left--price
-                    %p
-                      ¥3000
-                    %span  
-                      (税込み)
-                .relatedItems__list__item__detail__right
-                  = icon("fas","star")
-                  .relatedItems__list__item__detail__right--count
-                    0
-          = link_to "#" do
-            .relatedItems__list__item#categoryProduct
-              .relatedItems__list__item__image
-                = image_tag "products/product1.png"
-              .relatedItems__list__item__detail
-                .relatedItems__list__item__detail__left
-                  .relatedItems__list__item__detail__left--name
-                    %p
-                      商品名
-                  .relatedItems__list__item__detail__left--price
-                    %p
-                      ¥3000
-                    %span  
-                      (税込み)
-                .relatedItems__list__item__detail__right
-                  = icon("fas","star")
-                  .relatedItems__list__item__detail__right--count
-                    0
+          - @products.each do |product|
+            = link_to product_path(product) do
+              .relatedItems__list__item
+                .relatedItems__list__item__image
+                  = image_tag product .product_images[0].url.url
+                .relatedItems__list__item__detail
+                  .relatedItems__list__item__detail__left
+                    .relatedItems__list__item__detail__left--name
+                      %p
+                        = product.name
+                    .relatedItems__list__item__detail__left--price
+                      %p
+                        %span
+                          ¥
+                        %span
+                          = product.price
+                      %span  
+                        (税込み)
+                  .relatedItems__list__item__detail__right
+                    = icon("fas","star")
+                    .relatedItems__list__item__detail__right--count
+                      0
+
+          

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,11 +1,7 @@
 = render "layouts/main_header"
 
-.breadCrumbs
-  .breadCrumbs__category
-    %p FURIMA
-    %span
-      = icon("fas","chevron-right",class:"breadCrumbs__category--icon")
-    %p ベビー・キッズ
+- breadcrumb :product
+= render "layouts/breadcrumbs"
     
 - if current_user
   = render "products/show_login"

--- a/app/views/users/_user_header.html.haml
+++ b/app/views/users/_user_header.html.haml
@@ -7,7 +7,7 @@
       .searchbox
         = form_with(class: "search-form") do |f|
           = f.text_field :keyword, placeholder:"キーワードから検索する", class: "search-input"
-          %button.submit-btn
+          %button.submit-btn#user-submitBtn
             = icon("fas","search")
       %ul.resultList
 
@@ -24,10 +24,4 @@
         =link_to "ブランド", "#", class: "bland"
         %ul.brandsPulldowndisplayNone
 
-.breadCrumbs
-  .breadCrumbs__category
-    %p FURIMA
-    %span
-      = icon("fas","chevron-right",class:"breadCrumbs__category--icon")
-    %p 
-      マイページ
+

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -81,10 +81,6 @@
               %li.userbtn 
                 クレジットカード登録
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            -# = link_to logout_user_path(current_user.id) do
-              -# %li.userbtn 
-              -#   ログアウト
-              -#   = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
 
     .logout
       =link_to destroy_user_session_path, method: :delete do

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,5 +1,8 @@
 = render "user_header"
 
+- breadcrumb :logout
+= render "layouts/breadcrumbs"
+
 .userShow
   .userShow__container
     .userShow__container__left

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -19,7 +19,7 @@
               %li.userbtn 
                 やることリスト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to new_product_path do
               %li.userbtn 
                 出品する
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
@@ -69,7 +69,7 @@
           %p 設定
         .userShow__container__left__config__content
           %ul
-            = link_to "#" do
+            = link_to edit_user_path(current_user.id) do
               %li.userbtn 
                 ユーザー情報更新
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
@@ -81,10 +81,10 @@
               %li.userbtn 
                 クレジットカード登録
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
-              %li.userbtn 
-                ログアウト
-                = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
+            -# = link_to logout_user_path(current_user.id) do
+              -# %li.userbtn 
+              -#   ログアウト
+              -#   = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
 
     .logout
       =link_to destroy_user_session_path, method: :delete do

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -19,7 +19,7 @@
               %li.userbtn 
                 やることリスト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to new_product_path do
               %li.userbtn 
                 出品する
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
@@ -87,7 +87,7 @@
                 %li.userbtn 
                   登録クレジットカード一覧/削除
                   = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")
-            = link_to "#" do
+            = link_to logout_user_path(current_user.id) do
               %li.userbtn 
                 ログアウト
                 = icon("fas","chevron-right",class:"userShow__container__left__index__content--icon")

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,8 @@
 = render "user_header"
 
+- breadcrumb :user
+= render "layouts/breadcrumbs"
+
 .userShow
   .userShow__container
     .userShow__container__left

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,6 +3,11 @@ crumb :root do
   link "トップページ", root_path
 end
 
+# ユーザーマイページ
+crumb :user do
+  link "マイページ",user_path(current_user.id)
+end
+
 # カテゴリ一覧
 crumb :category_index do
   link "カテゴリー一覧", categories_path

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,63 @@
+# ルート
+crumb :root do
+  link "トップページ", root_path
+end
+
+# カテゴリ一覧
+crumb :category_index do
+  link "カテゴリー一覧", categories_path
+end
+
+# 親カテゴリ
+crumb :parent_category do |category|
+  category = Category.find(params[:id]).root
+  link "#{category.name}",category_path(category)
+  parent :category_index
+end
+
+# 子カテゴリ
+crumb :child_category do |category|
+  category = Category.find(params[:id])
+  # 表示ページが子カテゴリ一（子供がいる）場合
+  if category.has_children?
+    link "#{category.name}", category_path(category)
+    parent :parent_category
+    # 表示ページが孫カテゴリーの場合
+  else
+    link "#{category.parent.name}", category_path(category.parent)
+    parent :parent_category
+  end
+end
+
+# 孫カテゴリ
+crumb :grandchild_category do |category|
+  category = Category.find(params[:id])
+  link "#{category.name}", category_path(category)
+  parent :child_category
+end
+
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -8,6 +8,70 @@ crumb :user do
   link "マイページ",user_path(current_user.id)
 end
 
+# ログアウトページ
+crumb :logout do
+  link "ログアウト",logout_user_path(current_user.id)
+  parent :user
+end
+
+
+# クレジット新規登録
+crumb :credit_new do
+  link "クレジットカード新規登録",new_credit_card_path
+  parent :user
+end
+
+# クレジット一覧
+crumb :credit_index do
+  link "登録クレジットカード情報",credit_card_path(params[:id])
+  parent :user
+end
+
+# 商品詳細ページ
+crumb :product do |product|
+  product = Product.find(params[:id])
+  category = Category.find(product.category_id)
+  link "#{product.name}",product_path(product)
+  if category.has_children?
+    parent :product_child_category
+  else
+    parent :product_grandchild_category
+  end
+end
+
+# 商品詳細親カテゴリ
+crumb :product_parent_category do |product|
+  product = Product.find(params[:id])
+  category = Category.find(product.category_id).root
+  link "#{category.name}",category_path(category)
+  parent :category_index
+end
+
+# 商品詳細子カテゴリ
+crumb :product_child_category do |product|
+  product = Product.find(params[:id])
+  category = Category.find(product.category_id)
+  # 表示ページが子カテゴリ一（子供がいる）場合
+  if category.has_children?
+    link "#{category.name}", category_path(category)
+    parent :product_parent_category
+    # 表示ページが孫カテゴリーの場合
+  else
+    link "#{category.parent.name}", category_path(category.parent)
+    parent :product_parent_category
+  end
+end
+
+# 商品詳細孫カテゴリ
+crumb :product_grandchild_category do |product|
+  product = Product.find(params[:id])
+  category = Category.find(product.category_id)
+  link "#{category.name}", category_path(category)
+  parent :product_child_category
+end
+
+
+
 # カテゴリ一覧
 crumb :category_index do
   link "カテゴリー一覧", categories_path

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -37,27 +37,3 @@ crumb :grandchild_category do |category|
 end
 
 
-# crumb :projects do
-#   link "Projects", projects_path
-# end
-
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
-
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -14,6 +14,11 @@ crumb :logout do
   parent :user
 end
 
+# クレジット新規登録
+crumb :credit_delete do
+  link "クレジットカード情報削除",delete_credit_cards_path
+  parent :user
+end
 
 # クレジット新規登録
 crumb :credit_new do


### PR DESCRIPTION
# What
パンくずリスト機能の実装をおこなう。
また、それに伴いカテゴリー詳細ページ/商品詳細ページにて
カテゴリー商品の取得および一覧表示をできるようにする。

# Why
ユーザーの商品検索をしやすくするため。